### PR TITLE
Added ConsistentRead to find functions

### DIFF
--- a/examples/hierarchy.ts
+++ b/examples/hierarchy.ts
@@ -1,11 +1,5 @@
 import { DynamoDB } from 'aws-sdk';
-import {
-  Collection,
-  createContext,
-  insert,
-  find,
-  Context,
-} from '../dist';
+import { Collection, createContext, insert, find, Context } from '../dist';
 
 const DYNAMODB_ENDPOINT =
   process.env.DYNAMODB_ENDPOINT || 'http://localhost:8000';

--- a/src/operations/find_by_id.ts
+++ b/src/operations/find_by_id.ts
@@ -14,17 +14,23 @@ import debugDynamo from '../debug/debugDynamo';
  * @param context the context object
  * @param collectionName name of the collection to search
  * @param id the `_id` value of the root document
+ * @param options the the set of options for the search
+ * @param options.consistentRead search with strongly consistent reads
  * @returns the stored value, or `undefined` if not found
  * @throws {CollectionNotFoundException} when the collection is not found in the context
  */
 export async function findById<DocumentType extends DocumentWithId>(
   context: Context,
   collectionName: string,
-  id: string
+  id: string,
+  options?: {
+    consistentRead?: boolean;
+  }
 ): Promise<DocumentType | undefined> {
   const collection = getRootCollection(context, collectionName);
   const request: GetItemInput = {
     TableName: collection.layout.tableName,
+    ConsistentRead: options?.consistentRead,
     Key: Converter.marshall(
       {
         [collection.layout.primaryKey.partitionKey]: assemblePrimaryKeyValue(

--- a/src/operations/find_child_by_id.ts
+++ b/src/operations/find_child_by_id.ts
@@ -20,6 +20,8 @@ import debugDynamo from '../debug/debugDynamo';
  * @param collectionName name of the collection to search
  * @param id the `_id` value
  * @param rootObjectId the _id of the root object
+ * @param options the the set of options for the search
+ * @param options.consistentRead search with strongly consistent reads
  * @returns the stored value, or `undefined` if not found
  * @throws {CollectionNotFoundException} when the collection is not found in the context
  */
@@ -27,11 +29,15 @@ export async function findChildById<DocumentType extends DocumentWithId>(
   context: Context,
   collectionName: string,
   id: string,
-  rootObjectId: string
+  rootObjectId: string,
+  options?: {
+    consistentRead?: boolean;
+  }
 ): Promise<DocumentType | undefined> {
   const collection = getChildCollection(context, collectionName);
   const request: GetItemInput = {
     TableName: collection.layout.tableName,
+    ConsistentRead: options?.consistentRead,
     Key: Converter.marshall(
       {
         [collection.layout.primaryKey.partitionKey]: assemblePrimaryKeyValue(


### PR DESCRIPTION
Extending find_by_id and find_child_by_id to allow for Consistent Read.

This is not extended to Query yet as I'd like to put some safety checks around querying GSI with Consistent Read (which is not allowed).