### PR TITLE
support transaction writes for Replace/Insert via Put or Delete

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: sudo docker run --name dynamodb -d -p 8000:8000 amazon/dynamodb-local -jar DynamoDBLocal.jar -port 8000      
       - run: npm ci
-      - run: npm run lint
-      - run: LOCAL_DYNAMODB_ENDPOINT=http://localhost:8000 npm run test
+      - env:
+          LOCAL_DYNAMODB_ENDPOINT: http://localhost:8000
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy
+        run: LOCAL_DYNAMODB_ENDPOINT=http://localhost:8000 npm run test
 
+      - run: npm run lint
       - run: npm run prettier:check
       - run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{matrix.node-version}}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - run: sudo docker run --name dynamodb -d -p 8000:8000 amazon/dynamodb-local -jar DynamoDBLocal.jar -port 8000      
       - run: npm ci
       - run: npm run lint
-      - run: npm run test
+      - run: LOCAL_DYNAMODB_ENDPOINT=http://localhost:8000 npm run test
 
       - run: npm run prettier:check
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,12 @@
         "@types/jest": "^29.5.2",
         "@types/lodash": "^4.14.172",
         "@types/node": "^12.20.21",
+        "@types/object-hash": "^3.0.6",
         "@types/validator": "^13.6.3",
         "@types/verror": "^1.10.5",
         "debug": "^4.3.4",
         "lodash": "^4.17.21",
+        "object-hash": "^3.0.0",
         "validator": "^13.6.0",
         "verror": "^1.10.0"
       },
@@ -3970,6 +3972,11 @@
     "node_modules/@types/node": {
       "version": "12.20.55",
       "license": "MIT"
+    },
+    "node_modules/@types/object-hash": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.6.tgz",
+      "integrity": "sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w=="
     },
     "node_modules/@types/prettier": {
       "version": "2.7.3",
@@ -9700,6 +9707,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.2",
       "dev": true,
@@ -14798,6 +14813,11 @@
     "@types/node": {
       "version": "12.20.55"
     },
+    "@types/object-hash": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.6.tgz",
+      "integrity": "sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w=="
+    },
     "@types/prettier": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
@@ -18844,6 +18864,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true
+    },
+    "object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
     },
     "object-inspect": {
       "version": "1.12.2",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "author": "Chris Armstrong",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-sdk/client-dynamodb": "^3.50.0",
-    "@aws-sdk/util-dynamodb": "^3.50.0",
+    "@aws-sdk/client-dynamodb": "^3.53.0",
+    "@aws-sdk/util-dynamodb": "^3.53.0",
     "@swc/core": "^1.3.67",
     "@swc/jest": "^0.2.26",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
@@ -43,8 +43,8 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@aws-sdk/client-dynamodb": "^3.50.0",
-    "@aws-sdk/util-dynamodb": "^3.50.0"
+    "@aws-sdk/client-dynamodb": "^3.53.0",
+    "@aws-sdk/util-dynamodb": "^3.53.0"
   },
   "dependencies": {
     "@types/debug": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "doc": "typedoc --tsconfig tsconfig.json src/index.ts",
     "lint": "eslint '**/*.ts'",
     "test": "jest",
+    "test-local": "LOCAL_DYNAMODB_ENDPOINT=http://localhost:8000 npm run test",
     "prettier:check": "prettier -c **/*.ts",
     "prettier:write": "prettier --write **/*.ts",
     "test:watch": "jest --watch"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "dynaglue",
-  "version": "1.2.0-aplha.2",
+  "version": "1.2.0-alpha.2",
   "description": "dynaglue",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "dynaglue",
-  "version": "1.2.0-aplha.1",
+  "version": "1.2.0-aplha.2",
   "description": "dynaglue",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -51,10 +51,12 @@
     "@types/jest": "^29.5.2",
     "@types/lodash": "^4.14.172",
     "@types/node": "^12.20.21",
+    "@types/object-hash": "^3.0.6",
     "@types/validator": "^13.6.3",
     "@types/verror": "^1.10.5",
     "debug": "^4.3.4",
     "lodash": "^4.17.21",
+    "object-hash": "^3.0.0",
     "validator": "^13.6.0",
     "verror": "^1.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "dynaglue",
-  "version": "1.2.0-alpha.2",
+  "version": "1.2.0-alpha.3",
   "description": "dynaglue",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "dynaglue",
-  "version": "1.1.1",
+  "version": "1.2.0-aplha.1",
   "description": "dynaglue",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/base/coerce_error.ts
+++ b/src/base/coerce_error.ts
@@ -1,0 +1,16 @@
+import VError from 'verror';
+
+/**
+ * Given a caught exception, coerce it to an Error type through
+ * introspection. If it isn't a subclass of `Error`, wraps it
+ * in an InternalError
+ * @param error the error or not
+ * @returns an Error object
+ */
+export const coerceError = (error: unknown): Error => {
+  if (error instanceof Error) return error;
+  return new VError(
+    { name: 'unknown.error', info: { error } },
+    'An error of an unknown type occurred'
+  );
+};

--- a/src/base/exceptions.ts
+++ b/src/base/exceptions.ts
@@ -12,6 +12,16 @@ export class ConflictException extends VError {
 }
 
 /**
+ * Thrown when a replace or delete request(s) are rejected as part of transaction
+ * that already exists
+ */
+export class TransactionConflictException extends VError {
+  constructor(message: string) {
+    super({ name: 'transaction_conflict.error' }, message);
+  }
+}
+
+/**
  * Thrown when an `_id` value is specified that is not
  * valid (_id values must be a string).
  */
@@ -118,7 +128,7 @@ export class InvalidIndexedFieldValueException extends VError {
 export class InvalidQueryException extends VError {
   constructor(
     message: string,
-    { collection, query }: { collection: string; query: Record<string, unknown> }
+        { collection, query }: { collection: string; query: Record<string, unknown> }
   ) {
     super(
       {
@@ -232,6 +242,17 @@ export class InvalidBatchReplaceDeleteDescriptorException extends VError {
   }
 }
 
+/**
+ * When a TransactGetItems request conflicts with an
+ * ongoing TransactWriteItems operation on one or
+ * more items in the TransactGetItems request
+ */
+export class TransactionCanceledException extends VError {
+  constructor(message: string, info?: Record<string, unknown>) {
+    super({ name: 'transaction_cancelled', info }, message);
+  }
+}
+
 export class InvalidRangeOperatorException extends VError {
   constructor(message: string, operator: string) {
     super({ name: 'invalid_range_operator', info: { operator } }, message);
@@ -241,5 +262,23 @@ export class InvalidRangeOperatorException extends VError {
 export class IndexAccessPatternTypeException extends VError {
   constructor(message: string) {
     super({ name: 'index_access_pattern_type'}, message);
+  }
+}
+
+/**
+ * DynamoDB rejected the request because you retried a request with
+ * a different payload but with an idempotent token that was already used.
+ */
+export class IdempotentParameterMismatchException extends VError {
+  constructor(message: string) {
+    super({ name: 'idempotent_parameter_mismatch' }, message);
+  }
+}
+/**
+ * The transaction with the given request token is already in progress
+ */
+export class TransactionInProgressException extends VError {
+  constructor(message: string) {
+    super({ name: 'transaction_in_progress' }, message);
   }
 }

--- a/src/base/exceptions.ts
+++ b/src/base/exceptions.ts
@@ -1,5 +1,6 @@
 import { VError, Options as VErrorOptions } from 'verror';
 import { ParseElement } from './conditions_types';
+import { CancellationReason } from '@aws-sdk/client-dynamodb';
 
 /**
  * Thrown when insert() is called with a specified _id
@@ -251,7 +252,7 @@ export class InvalidBatchReplaceDeleteDescriptorException extends VError {
  * more items in the TransactGetItems request
  */
 export class TransactionCanceledException extends VError {
-  constructor(message: string, info?: Record<string, unknown>) {
+  constructor(message: string, info?: CancellationReason[]) {
     super({ name: 'transaction_cancelled', info }, message);
   }
 }

--- a/src/base/exceptions.ts
+++ b/src/base/exceptions.ts
@@ -1,6 +1,5 @@
 import { VError, Options as VErrorOptions } from 'verror';
 import { ParseElement } from './conditions_types';
-import { CancellationReason } from '@aws-sdk/client-dynamodb';
 
 /**
  * Thrown when insert() is called with a specified _id
@@ -181,6 +180,20 @@ export class InvalidUpdateValueException extends VError {
 }
 
 /**
+ * Throw when validations fails for arguments passed for any operation
+ */
+export class InvalidArgumentException extends VError {
+  constructor(message: string) {
+    super(
+      {
+        name: 'invalid_arguments',
+      },
+      message
+    );
+  }
+}
+
+/**
  * Throw when the find descriptor for a transactFindByIds or
  * batchFindByIds is invalid.
  */
@@ -252,7 +265,7 @@ export class InvalidBatchReplaceDeleteDescriptorException extends VError {
  * more items in the TransactGetItems request
  */
 export class TransactionCanceledException extends VError {
-  constructor(message: string, info?: CancellationReason[]) {
+  constructor(message: string, info?: Record<string, unknown>) {
     super({ name: 'transaction_cancelled', info }, message);
   }
 }
@@ -274,15 +287,14 @@ export class IndexAccessPatternTypeException extends VError {
  * a different payload but with an idempotent token that was already used.
  */
 export class IdempotentParameterMismatchException extends VError {
-  constructor(message: string) {
-    super({ name: 'idempotent_parameter_mismatch' }, message);
+  constructor(message: string, info?: Record<string, unknown>) {
+    super({ name: 'idempotent_parameter_mismatch', info }, message);
   }
 }
 
 /**
  * Transaction request cannot include multiple operations on one item
  */
-
 export class TransactionValidationException extends VError {
   constructor(message: string) {
     super({ name: 'transaction_validation' }, message);
@@ -292,7 +304,7 @@ export class TransactionValidationException extends VError {
  * The transaction with the given request token is already in progress
  */
 export class TransactionInProgressException extends VError {
-  constructor(message: string) {
-    super({ name: 'transaction_in_progress' }, message);
+  constructor(message: string, info?: Record<string, unknown>) {
+    super({ name: 'transaction_in_progress', info }, message);
   }
 }

--- a/src/base/exceptions.ts
+++ b/src/base/exceptions.ts
@@ -128,7 +128,10 @@ export class InvalidIndexedFieldValueException extends VError {
 export class InvalidQueryException extends VError {
   constructor(
     message: string,
-        { collection, query }: { collection: string; query: Record<string, unknown> }
+    {
+      collection,
+      query,
+    }: { collection: string; query: Record<string, unknown> }
   ) {
     super(
       {
@@ -261,7 +264,7 @@ export class InvalidRangeOperatorException extends VError {
 
 export class IndexAccessPatternTypeException extends VError {
   constructor(message: string) {
-    super({ name: 'index_access_pattern_type'}, message);
+    super({ name: 'index_access_pattern_type' }, message);
   }
 }
 
@@ -272,6 +275,16 @@ export class IndexAccessPatternTypeException extends VError {
 export class IdempotentParameterMismatchException extends VError {
   constructor(message: string) {
     super({ name: 'idempotent_parameter_mismatch' }, message);
+  }
+}
+
+/**
+ * Transaction request cannot include multiple operations on one item
+ */
+
+export class TransactionValidationException extends VError {
+  constructor(message: string) {
+    super({ name: 'transaction_validation' }, message);
   }
 }
 /**

--- a/src/debug/debugDynamoTests.ts
+++ b/src/debug/debugDynamoTests.ts
@@ -1,0 +1,15 @@
+import debug from 'debug';
+
+export const DebugTestsNamespace = 'dynaglue:dynamodb:test';
+
+/** @internal */
+const logger = debug(DebugTestsNamespace);
+
+/**
+ * @internal
+ *
+ * Helper for logging dynamo requests
+ */
+export const debugDynamoTests = (message: string, data: unknown): void => {
+  logger('%s: %O', message, data);
+};

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,0 +1,2 @@
+export * from './debugDynamo';
+export * from './debugDynamoTests';

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,2 +1,1 @@
 export * from './debugDynamo';
-export * from './debugDynamoTests';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
   findByIdWithChildren,
   batchFindByIds,
   batchReplaceDelete,
+  transactionWrite,
 } from './operations';
 export type { Context };
 export { createContext };
@@ -107,4 +108,10 @@ export type {
   BatchReplaceDeleteDescriptor,
   BatchReplaceDeleteResponse,
 } from './operations/batch_replace_delete';
+export type {
+  TransactionDeleteRequest,
+  TransactionDeleteChildRequest,
+  TransactionReplaceRequest,
+  TransactionWriteRequest,
+} from './operations/transact_write';
 export type { ParseElement } from './base/conditions_types';

--- a/src/operations/batch_find_by_ids.ts
+++ b/src/operations/batch_find_by_ids.ts
@@ -139,7 +139,7 @@ export const batchFindByIds = async (
   }, {} as { [collection: string]: KeysAndAttributes });
 
   const request = { RequestItems: requestItems };
-  debugDynamo('batchGetItem', request);
+  debugDynamo('BatchGetItem', request);
   const command = new BatchGetItemCommand(request);
   const { Responses = {}, UnprocessedKeys = {} } = await ctx.ddb.send(command);
 

--- a/src/operations/batch_replace_delete.ts
+++ b/src/operations/batch_replace_delete.ts
@@ -166,14 +166,14 @@ export const batchReplaceDelete = async (
       items.push(request);
       return riMap;
     },
-    {} as { [key: string]: WriteRequest [] },
+    {} as { [key: string]: WriteRequest[] },
   );
 
   const request: BatchWriteItemInput = {
     RequestItems: requestItems,
   };
 
-  debugDynamo('batchWriteItem', request);
+  debugDynamo('BatchWriteItem', request);
   const command = new BatchWriteItemCommand(request);
   const { UnprocessedItems = {} } = await ctx.ddb.send(command);
 

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -11,3 +11,4 @@ export { updateChildById } from './update_child_by_id';
 export { findByIdWithChildren } from './find_by_id_with_children';
 export { batchFindByIds } from './batch_find_by_ids';
 export { batchReplaceDelete } from './batch_replace_delete';
+export { transactionWrite } from './transact_write';

--- a/src/operations/replace.ts
+++ b/src/operations/replace.ts
@@ -2,7 +2,7 @@ import { PutItemCommand, PutItemInput } from '@aws-sdk/client-dynamodb';
 import { marshall } from '@aws-sdk/util-dynamodb';
 import { Context } from '../context';
 import { toWrapped, getCollection } from '../base/util';
-import { DocumentWithId } from '../base/common';
+import { DocumentWithId, WrappedDocument } from '../base/common';
 import { createNameMapper, createValueMapper } from '../base/mappers';
 import debugDynamo from '../debug/debugDynamo';
 import { CompositeCondition } from '../base/conditions';
@@ -20,7 +20,7 @@ import { parseCompositeCondition } from '../base/conditions_parser';
  * @param collectionName the collection to update
  * @param value the document to insert or replace
  * @param options options to apply
- * @param options.condition an optional conditional expression that must be satifisfied for the update to proceed
+ * @param options.condition an optional conditional expression that must be satisfied for the update to proceed
  * @returns the inserted / replaced value
  * @throws {CollectionNotFoundException} when the collection is not found
  */
@@ -30,6 +30,41 @@ export async function replace<DocumentType extends DocumentWithId>(
   value: Record<string, unknown>,
   options: { condition?: CompositeCondition } = {}
 ): Promise<DocumentType> {
+  const { request, wrapped } = createReplaceByIdRequest(
+    context,
+    collectionName,
+    value,
+    options
+  );
+
+  debugDynamo('PutItem', request);
+  const command = new PutItemCommand(request);
+  await context.ddb.send(command);
+  return (wrapped as WrappedDocument<DocumentType>).value;
+}
+
+/**
+ * Create a request for Insert or Replace request
+ *
+ * This operation differs from [[insert]] in that it does not check for the existence
+ * of a document with the same `_id` value - it will replace whatever is there.
+ *
+ * @category Mutation
+ *
+ * @param context the context
+ * @param collectionName the collection to update
+ * @param value the document to insert or replace
+ * @param options options to apply
+ * @param options.condition an optional conditional expression that must be satisfied for the update to proceed
+ * @returns the inserted / replaced request @see {PutItemInput}
+ * @throws {CollectionNotFoundException} when the collection is not found
+ */
+export const createReplaceByIdRequest = <DocumentType extends DocumentWithId>(
+  context: Context,
+  collectionName: string,
+  value: Record<string, unknown>,
+  options: { condition?: CompositeCondition } = {}
+): { request: PutItemInput; wrapped: WrappedDocument<DocumentType> } => {
   const collection = getCollection(context, collectionName);
   const wrapped = toWrapped<DocumentType>(collection, value);
 
@@ -44,16 +79,18 @@ export async function replace<DocumentType extends DocumentWithId>(
     });
   }
 
+  const item = marshall(wrapped, {
+    convertEmptyValues: false,
+    removeUndefinedValues: true,
+  });
   const request: PutItemInput = {
     TableName: collection.layout.tableName,
-    Item: marshall(wrapped, { convertEmptyValues: false, removeUndefinedValues: true }),
+    Item: item,
     ReturnValues: 'NONE',
     ConditionExpression: conditionExpression,
     ExpressionAttributeNames: nameMapper.get(),
     ExpressionAttributeValues: valueMapper.get(),
   };
-  debugDynamo('PutItem', request);
-  const command = new PutItemCommand(request);
-  await context.ddb.send(command);
-  return wrapped.value;
-}
+
+  return { request, wrapped };
+};

--- a/src/operations/transact_find_by_ids.ts
+++ b/src/operations/transact_find_by_ids.ts
@@ -1,4 +1,7 @@
-import { TransactGetItem, TransactGetItemsCommand } from '@aws-sdk/client-dynamodb';
+import {
+  TransactGetItem,
+  TransactGetItemsCommand,
+} from '@aws-sdk/client-dynamodb';
 import { convertToAttr, unmarshall } from '@aws-sdk/util-dynamodb';
 import { Context } from '../context';
 import { InvalidFindDescriptorException } from '../base/exceptions';
@@ -72,14 +75,13 @@ export const transactFindByIds = async <DocumentType extends DocumentWithId>(
   const command = new TransactGetItemsCommand(request);
   const { Responses = [] } = await ctx.ddb.send(command);
 
-  const returnedItems = new Array(items.length);
+  const returnedItems = [];
   for (const response of Responses) {
-    let item = null;
     if (response.Item) {
       const unmarshalled = unmarshall(response.Item);
-      item = unwrap(unmarshalled as WrappedDocument<DocumentType>);
+      const item = unwrap(unmarshalled as WrappedDocument<DocumentType>);
+      returnedItems.push(item);
     }
-    returnedItems.push(item);
   }
   return returnedItems;
 };

--- a/src/operations/transact_find_by_ids.ts
+++ b/src/operations/transact_find_by_ids.ts
@@ -57,7 +57,7 @@ export const transactFindByIds = async <DocumentType extends DocumentWithId>(
               assemblePrimaryKeyValue(
                 rootId
                   ? (collectionDefinition as ChildCollection)
-                      .parentCollectionName
+                    .parentCollectionName
                   : collectionDefinition.name,
                 rootId ? rootId : id,
                 indexKeySeparator
@@ -75,7 +75,7 @@ export const transactFindByIds = async <DocumentType extends DocumentWithId>(
   );
 
   const request = { TransactItems: transactGetItems };
-  debugDynamo('transactGetItems', request);
+  debugDynamo('TransactGetItems', request);
   const command = new TransactGetItemsCommand(request);
   const { Responses = [] } = await ctx.ddb.send(command);
 

--- a/src/operations/transact_find_by_ids.ts
+++ b/src/operations/transact_find_by_ids.ts
@@ -13,6 +13,7 @@ import {
 } from '../base/util';
 import { DocumentWithId, WrappedDocument } from '../base/common';
 import debugDynamo from '../debug/debugDynamo';
+import { ChildCollection } from '../base/collection';
 
 /**
  * The collection and ID of a root or child
@@ -54,7 +55,10 @@ export const transactFindByIds = async <DocumentType extends DocumentWithId>(
           Key: {
             [primaryKey.partitionKey]: convertToAttr(
               assemblePrimaryKeyValue(
-                collection,
+                rootId
+                  ? (collectionDefinition as ChildCollection)
+                      .parentCollectionName
+                  : collectionDefinition.name,
                 rootId ? rootId : id,
                 indexKeySeparator
               ),

--- a/src/operations/transact_write.test.ts
+++ b/src/operations/transact_write.test.ts
@@ -162,6 +162,7 @@ describe('transactions', () => {
       const request = [
         // Insert Item
         {
+          type: 'replace',
           collectionName: collection.name,
           value: {
             _id: 'test-jw',
@@ -174,6 +175,7 @@ describe('transactions', () => {
         },
         // Update Item
         {
+          type: 'replace',
           collectionName: collection.name,
           value: {
             _id: 'test-sh',
@@ -184,22 +186,19 @@ describe('transactions', () => {
         },
         // Delete Item
         {
+          type: 'delete',
           collectionName: collection.name,
           id: 'test-id',
         },
         // Delete Child Item
         {
+          type: 'delete-child',
           collectionName: childCollection.name,
           id: 'test-id-meta',
           rootObjectId: 'test-id',
         },
       ] as TransactionWriteRequest[];
 
-      /*
-       * Note:
-       * passing custom token as running tests again and again with same payload results
-       * in same token, hence assertion fails
-       */
       const ClientRequestToken = objectHash(new Date().getTime(), {
         algorithm: 'md5',
         encoding: 'base64',
@@ -266,6 +265,7 @@ describe('transactions', () => {
       const request = [
         // update a existing user
         {
+          type: 'replace',
           collectionName: collection.name,
           value: {
             _id: 'test-id-1',
@@ -275,6 +275,7 @@ describe('transactions', () => {
         },
         // Deleting same user as above updated user
         {
+          type: 'delete',
           collectionName: collection.name,
           id: 'test-id-1',
         },
@@ -286,15 +287,9 @@ describe('transactions', () => {
     });
 
     test('writing same transaction twice with same `ClientRequestToken` to ddb', async () => {
-      /**
-       * Note:
-       * We can either create token ourselves
-       *  or
-       * it's generated implicitly based on request payload
-       */
-
       const request = [
         {
+          type: 'replace',
           collectionName: collection.name,
           value: {
             _id: 'test-bob',
@@ -306,8 +301,13 @@ describe('transactions', () => {
         },
       ] as TransactionWriteRequest[];
 
-      await transactionWrite(context, request);
-      await transactionWrite(context, request);
+      const ClientRequestToken = objectHash(new Date().getTime(), {
+        algorithm: 'md5',
+        encoding: 'base64',
+      });
+
+      await transactionWrite(context, request, { ClientRequestToken });
+      await transactionWrite(context, request, { ClientRequestToken });
     });
 
     test('IdempotentParameterMismatchException while writing different transaction with same `ClientRequestToken` to ddb', async () => {
@@ -318,6 +318,7 @@ describe('transactions', () => {
 
       const request1 = [
         {
+          type: 'replace',
           collectionName: collection.name,
           value: {
             _id: 'test-pat',
@@ -333,6 +334,7 @@ describe('transactions', () => {
 
       const request2 = [
         {
+          type: 'replace',
           collectionName: collection.name,
           value: {
             _id: 'test-bob',

--- a/src/operations/transact_write.test.ts
+++ b/src/operations/transact_write.test.ts
@@ -1,0 +1,251 @@
+import {
+  CreateTableCommand,
+  CreateTableInput,
+  DeleteTableCommand,
+  DynamoDBClient,
+  ListTablesCommand,
+} from '@aws-sdk/client-dynamodb';
+import { CollectionLayout } from '../base/layout';
+import { createContext } from '../context';
+import { replace } from './replace';
+import {
+  TransactFindByIdDescriptor,
+  transactFindByIds,
+} from './transact_find_by_ids';
+import { TransactionWriteRequest, transactionWrite } from './transact_write';
+import debug from 'debug';
+import { DebugTestsNamespace, debugDynamoTests } from '../debug';
+
+const TableDefinitions = [
+  {
+    TableName: 'User',
+    KeySchema: [
+      { AttributeName: 'pk', KeyType: 'HASH' },
+      { AttributeName: 'sk', KeyType: 'RANGE' },
+    ],
+    AttributeDefinitions: [
+      { AttributeName: 'pk', AttributeType: 'S' },
+      { AttributeName: 'sk', AttributeType: 'S' },
+    ],
+    ProvisionedThroughput: { ReadCapacityUnits: 1, WriteCapacityUnits: 1 },
+  },
+];
+
+const layout: CollectionLayout = {
+  tableName: 'User',
+  primaryKey: { partitionKey: 'pk', sortKey: 'sk' },
+};
+const collection = {
+  name: 'users',
+  layout,
+};
+
+const showTimeTaken = (startTime: number) =>
+  `[${new Date().getTime() - startTime}ms]`;
+
+const LocalDDBTestKit = {
+  connect: (): DynamoDBClient | null => {
+    const startBy = new Date().getTime();
+    try {
+      const localDDBClient = new DynamoDBClient({
+        endpoint: 'http://localhost:8000',
+        region: 'local',
+      });
+      debugDynamoTests(`${showTimeTaken(startBy)} Connected to Local DDB`, '');
+      return localDDBClient;
+    } catch (error) {
+      debugDynamoTests('Error connecting to local DDB', error);
+      return null;
+    }
+  },
+  createTables: async (
+    client: DynamoDBClient,
+    tableDefinitions: CreateTableInput[] = []
+  ) => {
+    const startBy = new Date().getTime();
+    try {
+      await Promise.all(
+        tableDefinitions?.map((tableDefinition) => {
+          const createTableCmd = new CreateTableCommand(tableDefinition);
+          return client.send(createTableCmd);
+        })
+      );
+
+      debugDynamoTests(
+        `${showTimeTaken(startBy)} tables created in local DDB`,
+        ''
+      );
+    } catch (error) {
+      debugDynamoTests('Error creating tables in local DDB', error);
+    }
+  },
+  deleteTables: async (client: DynamoDBClient, tableNames: string[] = []) => {
+    const startBy = new Date().getTime();
+    try {
+      await Promise.all(
+        tableNames?.map((tableName) => {
+          return client.send(
+            new DeleteTableCommand({
+              TableName: tableName,
+            })
+          );
+        })
+      );
+
+      debugDynamoTests(
+        `${showTimeTaken(startBy)} tables deleted in local DDB`,
+        ''
+      );
+    } catch (error) {
+      debugDynamoTests('Error deleting tables in local DDB', error);
+    }
+  },
+  listTables: async (client: DynamoDBClient) => {
+    try {
+      await client.send(new ListTablesCommand({}));
+    } catch (error) {
+      debugDynamoTests('Error listing tables in local DDB', error);
+    }
+  },
+};
+
+describe('transactions', () => {
+  let localDDBClient: DynamoDBClient;
+
+  // create a client with DDB local
+  beforeAll(async () => {
+    debug.enable(DebugTestsNamespace);
+    localDDBClient = LocalDDBTestKit.connect() as unknown as DynamoDBClient;
+  });
+
+  // create tables
+  beforeAll(async () => {
+    await LocalDDBTestKit.createTables(localDDBClient, TableDefinitions);
+  });
+
+  // Delete tables
+  afterAll(async () => {
+    await LocalDDBTestKit.deleteTables(localDDBClient, [
+      TableDefinitions[0].TableName,
+    ]);
+    debug.disable();
+  });
+
+  test.each([
+    { _id: 'test-id', name: 'Moriarty', email: 'moriarty@jim.com' },
+    {
+      _id: 'test-sh',
+      name: 'Sherlock',
+      email: 'sh@sh.com',
+    },
+  ])('Insert items to the collection using replace', async (value) => {
+    const context = createContext(localDDBClient as unknown as DynamoDBClient, [
+      collection,
+    ]);
+
+    const result = await replace(context, collection.name, value, {
+      condition: { _id: { $exists: false } }, // condition to check user doesn't exists
+    });
+    expect(result).toHaveProperty('_id');
+  });
+
+  test('fetch items using transaction', async () => {
+    const context = createContext(localDDBClient as unknown as DynamoDBClient, [
+      collection,
+    ]);
+
+    const items: TransactFindByIdDescriptor[] = [
+      {
+        id: 'test-sh',
+        collection: collection.name,
+      },
+      {
+        id: 'test-id',
+        collection: collection.name,
+      },
+    ];
+    const result = await transactFindByIds(context, items);
+
+    debugDynamoTests(
+      'fetched items using transactFindByIds',
+      JSON.stringify(result)
+    );
+
+    expect(result).toEqual([
+      { name: 'Sherlock', email: 'sh@sh.com', _id: 'test-sh' },
+      { name: 'Moriarty', email: 'moriarty@jim.com', _id: 'test-id' },
+    ]);
+  });
+
+  test('write a transaction to ddb consisting multiple ops', async () => {
+    const context = createContext(localDDBClient as unknown as DynamoDBClient, [
+      collection,
+    ]);
+
+    const request = [
+      {
+        collectionName: collection.name,
+        value: {
+          _id: 'test-jw',
+          lastName: 'Watson',
+          firstName: 'John',
+          email: 'jw@sh.sh',
+        },
+        options: { condition: { _id: { $exists: false } } }, // an insertion
+      },
+      {
+        collectionName: collection.name,
+        value: {
+          _id: 'test-sh',
+          lastName: 'Holmes',
+          firstName: 'Sherlock',
+          email: 'sh@sh.sh',
+        }, // an update to existing user
+      },
+      {
+        collectionName: collection.name,
+        id: 'test-id',
+      }, // a deletion
+    ] as TransactionWriteRequest[];
+
+    transactionWrite(context, request);
+  });
+
+  test('fetch inserted, updated(replaced) or deleted items using transaction', async () => {
+    const context = createContext(localDDBClient as unknown as DynamoDBClient, [
+      collection,
+    ]);
+
+    const items: TransactFindByIdDescriptor[] = [
+      {
+        id: 'test-sh',
+        collection: collection.name,
+      },
+      {
+        id: 'test-jw',
+        collection: collection.name,
+      },
+      {
+        id: 'test-id',
+        collection: collection.name,
+      },
+    ];
+
+    const result = await transactFindByIds(context, items);
+
+    expect(result).toEqual([
+      {
+        lastName: 'Holmes',
+        firstName: 'Sherlock',
+        _id: 'test-sh',
+        email: 'sh@sh.sh',
+      },
+      {
+        lastName: 'Watson',
+        firstName: 'John',
+        _id: 'test-jw',
+        email: 'jw@sh.sh',
+      },
+    ]);
+  });
+});

--- a/src/operations/transact_write.ts
+++ b/src/operations/transact_write.ts
@@ -1,0 +1,134 @@
+import {
+  Delete,
+  Put,
+  TransactWriteItem,
+  TransactWriteItemsCommand,
+} from '@aws-sdk/client-dynamodb';
+import { CompositeCondition } from '../base/conditions';
+import {
+  InvalidFindDescriptorException,
+  TransactionCanceledException,
+  TransactionConflictException,
+} from '../base/exceptions';
+import { Context } from '../context';
+import debugDynamo from '../debug/debugDynamo';
+import { createDeleteByIdRequest } from './delete_by_id';
+import { createReplaceByIdRequest } from './replace';
+
+/**
+ * @param collectionName the collection to update
+ * @param value the document to insert or replace
+ * @param options options to apply
+ * @param options.condition an optional conditional expression that must be satisfied for the update to proceed
+ */
+export type TransactionReplaceRequest = {
+  collectionName: string;
+  value: Record<string, unknown>;
+  options?: { condition?: CompositeCondition };
+};
+
+/**
+ * @param collectionName the collection to update
+ * @param id the document to delete
+ * @param options options to apply
+ * @param options.condition an optional conditional expression that must be satisfied for the update to proceed
+ */
+export type TransactionDeleteRequest = {
+  collectionName: string;
+  id: string;
+  options?: { condition?: CompositeCondition };
+};
+
+export type TransactionWriteRequest =
+  | TransactionReplaceRequest
+  | TransactionDeleteRequest;
+
+const isTransactionReplaceRequest = (
+  transactionWriteRequest: TransactionWriteRequest
+): transactionWriteRequest is TransactionReplaceRequest =>
+  'value' in transactionWriteRequest && !!transactionWriteRequest.value;
+
+const isTransactionDeleteRequest = (
+  transactionWriteRequest: TransactionDeleteRequest
+): transactionWriteRequest is TransactionDeleteRequest =>
+  'id' in transactionWriteRequest && !!transactionWriteRequest.id;
+
+/**
+ * This operation writes to DynamoDB in a transaction.
+ * A transaction can contain upto 25 operations (Insert, Replace or Delete)
+ *
+ * @category Mutation
+ *
+ * @param context
+ * @param transactionWriteRequests
+ * @throws {TransactionCanceledException}
+ * @throws {TransactionConflictException}
+ */
+export const transactionWrite = async (
+  context: Context,
+  transactionWriteRequests: TransactionWriteRequest[]
+): Promise<void> => {
+  if (!transactionWriteRequests || transactionWriteRequests.length === 0) {
+    throw new InvalidFindDescriptorException(
+      'At least one request should be provided'
+    );
+  } else if (transactionWriteRequests.length > 25) {
+    throw new InvalidFindDescriptorException(
+      'No more than 25 requests can be specified to transactionWrite'
+    );
+  }
+  const transactWriteItem: TransactWriteItem[] = transactionWriteRequests.map(
+    (request) => {
+      /** Checks and create a REPLACE request for a requested item */
+      if (isTransactionReplaceRequest(request)) {
+        const { collectionName, value, options } = request;
+        const { request: putItemInput } = createReplaceByIdRequest(
+          context,
+          collectionName,
+          value,
+          options
+        );
+
+        return { Put: putItemInput } as { Put: Put };
+      }
+
+      /** Checks and create a DELETE request for a requested item */
+      if (isTransactionDeleteRequest(request)) {
+        const { collectionName, id, options } = request;
+
+        const deleteItem = createDeleteByIdRequest(
+          context,
+          collectionName,
+          id,
+          options
+        );
+
+        return { Delete: deleteItem } as { Delete: Delete };
+      }
+    }
+  ) as unknown as TransactWriteItem[];
+
+  try {
+    const request = { TransactItems: transactWriteItem };
+
+    debugDynamo('transactWriteItems', JSON.stringify(request));
+
+    const command = new TransactWriteItemsCommand(request);
+    await context.ddb.send(command);
+  } catch (error) {
+    console.error('Error in writing transactions to DynamoDB : ', error);
+
+    // ToDo :: below 2 can be merged
+    if ((error as Error).name === 'TransactionCanceledException') {
+      throw new TransactionCanceledException(
+        'The entire transaction request was canceled'
+      );
+    }
+    if ((error as Error).name === 'TransactionConflictException') {
+      throw new TransactionConflictException(
+        'Another transaction or request is in progress for one of the requested item'
+      );
+    }
+    throw error;
+  }
+};

--- a/src/operations/transact_write.ts
+++ b/src/operations/transact_write.ts
@@ -6,6 +6,7 @@ import {
   TransactionCanceledException as DDBTransactionCanceledException,
   TransactWriteItem,
   TransactWriteItemsCommand,
+  TransactWriteItemsCommandOutput,
 } from '@aws-sdk/client-dynamodb';
 import { CompositeCondition } from '../base/conditions';
 import {
@@ -104,7 +105,7 @@ export const transactionWrite = async (
     ReturnItemCollectionMetrics?: ReturnItemCollectionMetrics | string;
     ClientRequestToken?: string;
   } = {}
-): Promise<void> => {
+): Promise<TransactWriteItemsCommandOutput> => {
   if (!transactionWriteRequests || transactionWriteRequests.length === 0) {
     throw new InvalidFindDescriptorException(
       'At least one request should be provided'
@@ -175,7 +176,7 @@ export const transactionWrite = async (
 
     const command = new TransactWriteItemsCommand(request);
 
-    await context.ddb.send(command);
+    return await context.ddb.send(command);
   } catch (error) {
     console.error('Error writing transaction to dynamo db : ', error);
 

--- a/src/operations/transact_write.ts
+++ b/src/operations/transact_write.ts
@@ -9,6 +9,7 @@ import {
   InvalidFindDescriptorException,
   TransactionCanceledException,
   TransactionConflictException,
+  TransactionValidationException,
 } from '../base/exceptions';
 import { Context } from '../context';
 import debugDynamo from '../debug/debugDynamo';
@@ -118,7 +119,11 @@ export const transactionWrite = async (
   } catch (error) {
     console.error('Error in writing transactions to DynamoDB : ', error);
 
-    // ToDo :: below 2 can be merged
+    if ((error as Error).name === 'ValidationException') {
+      throw new TransactionValidationException(
+        'Multiple operations are included for same item id'
+      );
+    }
     if ((error as Error).name === 'TransactionCanceledException') {
       throw new TransactionCanceledException(
         'The entire transaction request was canceled'

--- a/testutil/debug_tests.ts
+++ b/testutil/debug_tests.ts
@@ -10,6 +10,6 @@ const logger = debug(DebugTestsNamespace);
  *
  * Helper for logging dynamo requests
  */
-export const debugDynamoTests = (message: string, data: unknown): void => {
+export const debugTests = (message: string, data: unknown): void => {
   logger('%s: %O', message, data);
 };

--- a/testutil/local_dynamo_db.ts
+++ b/testutil/local_dynamo_db.ts
@@ -1,0 +1,76 @@
+import {
+  CreateTableCommand,
+  CreateTableInput,
+  DeleteTableCommand,
+  DynamoDBClient,
+  ListTablesCommand,
+} from '@aws-sdk/client-dynamodb';
+import { debugTests } from './debug_tests';
+
+const showTimeTaken = (startTime: number) =>
+  `[${new Date().getTime() - startTime}ms]`;
+
+const LocalDDBTestKit = {
+  connect: (): DynamoDBClient | null => {
+    const startBy = new Date().getTime();
+    try {
+      const localDDBClient = new DynamoDBClient({
+        endpoint: 'http://localhost:8000',
+        region: 'local',
+      });
+      debugTests(`${showTimeTaken(startBy)} Connected to Local DDB`, '');
+      return localDDBClient;
+    } catch (error) {
+      debugTests('Error connecting to local DDB', error);
+      return null;
+    }
+  },
+  createTables: async (
+    client: DynamoDBClient,
+    tableDefinitions: CreateTableInput[] = []
+  ): Promise<void> => {
+    const startBy = new Date().getTime();
+    try {
+      await Promise.all(
+        tableDefinitions?.map((tableDefinition) => {
+          const createTableCmd = new CreateTableCommand(tableDefinition);
+          return client.send(createTableCmd);
+        })
+      );
+
+      debugTests(`${showTimeTaken(startBy)} tables created in local DDB`, '');
+    } catch (error) {
+      debugTests('Error creating tables in local DDB', error);
+    }
+  },
+  deleteTables: async (
+    client: DynamoDBClient,
+    tableNames: string[] = []
+  ): Promise<void> => {
+    const startBy = new Date().getTime();
+    try {
+      await Promise.all(
+        tableNames?.map((tableName) => {
+          return client.send(
+            new DeleteTableCommand({
+              TableName: tableName,
+            })
+          );
+        })
+      );
+
+      debugTests(`${showTimeTaken(startBy)} tables deleted in local DDB`, '');
+    } catch (error) {
+      debugTests('Error deleting tables in local DDB', error);
+    }
+  },
+  listTables: async (client: DynamoDBClient): Promise<void> => {
+    try {
+      await client.send(new ListTablesCommand({}));
+    } catch (error) {
+      debugTests('Error listing tables in local DDB', error);
+    }
+  },
+};
+
+export default LocalDDBTestKit;


### PR DESCRIPTION
- Added the support for transaction writes for Replace/Insert via PutItem and Delete for DeleteItem
- Transaction write supports Idempotency by creating client token for every request using `object-hash` lib to generate hash with request payload 
- Fixed the bug with transaction read for finding child using Get
